### PR TITLE
FC Cincinnati vs. Minnesota United FC | October 24, 2020

### DIFF
--- a/_posts/mnufc/2020-10-24-FC-Cincinnati-vs-Minnesota-United-FC.md
+++ b/_posts/mnufc/2020-10-24-FC-Cincinnati-vs-Minnesota-United-FC.md
@@ -1,0 +1,16 @@
+---
+title: FC Cincinnati vs. Minnesota United FC | October 24, 2020
+date: Sat Oct 24 2020 00:00:00 GMT+0000 (Coordinated Universal Time)
+permalink: 2020_10_24_fc_cincinnati_vs_minnesota_united_fc_md
+excerpt: Desperate for three points to stay in the chase for a playoff spot in the Eastern Conference, FC Cincinnati host a Minnesota United squad unbeaten in their last five in the first-ever match between the sides at Nippert Stadium Saturday night.FC Cincinnati (4W-11L-4D) are coming off a devastating 2-1 home defeat to D.C. United Sunday, while the Loons (6W-5L-6D) squandered a two-goal lead to settle for a third draw in the last four games, playing the Houston Dynamo to a 2-2 home stalemate Sunday.This is the second meeting this season, with Minnesota United winning 2-0 at Allianz Field Oct. 3 with Kei Kamara and Kevin Molino scoring a goal in each half.
+author: Matt Erickson (ME)
+layout: post
+tags:
+  - mnufc
+  - soccer
+  - auto-post
+hidden: true
+---
+<div class='soccer-video-wrapper'>
+    <iframe class='soccer-video' width='100%' height='auto' frameborder='0' allowfullscreen src='https://www.mnufc.com/iframe-video?brightcove_id=6204457054001&brightcove_player_id=default&brightcove_account_id=5534894110001'></iframe>
+  </div>


### PR DESCRIPTION
Desperate for three points to stay in the chase for a playoff spot in the Eastern Conference, FC Cincinnati host a Minnesota United squad unbeaten in their last five in the first-ever match between the sides at Nippert Stadium Saturday night.FC Cincinnati (4W-11L-4D) are coming off a devastating 2-1 home defeat to D.C. United Sunday, while the Loons (6W-5L-6D) squandered a two-goal lead to settle for a third draw in the last four games, playing the Houston Dynamo to a 2-2 home stalemate Sunday.This is the second meeting this season, with Minnesota United winning 2-0 at Allianz Field Oct. 3 with Kei Kamara and Kevin Molino scoring a goal in each half.