### PR TITLE
Minnesota United FC vs. Colorado Rapids | November 22, 2020

### DIFF
--- a/_posts/mnufc/2020-11-22-Minnesota-United-FC-vs-Colorado-Rapids.md
+++ b/_posts/mnufc/2020-11-22-Minnesota-United-FC-vs-Colorado-Rapids.md
@@ -1,0 +1,16 @@
+---
+title: Minnesota United FC vs. Colorado Rapids | November 22, 2020
+date: Sun Nov 22 2020 00:00:00 GMT+0000 (Coordinated Universal Time)
+permalink: 2020_11_22_minnesota_united_fc_vs_colorado_rapids_md
+excerpt: For a second straight season Minnesota United have secured a home Audi MLS Cup Playoffs game, with the Loons seeking their first postseason win against a Colorado Rapids side eager to play the underdog role in a Round One showdown at Allianz Field Nov. 22.
+author: Matt Erickson (ME)
+layout: post
+tags:
+  - mnufc
+  - soccer
+  - auto-post
+hidden: true
+---
+<div class='soccer-video-wrapper'>
+    <iframe class='soccer-video' width='100%' height='auto' frameborder='0' allowfullscreen src='https://www.mnufc.com/iframe-video?brightcove_id=6211628378001&brightcove_player_id=default&brightcove_account_id=5534894110001'></iframe>
+  </div>


### PR DESCRIPTION
For a second straight season Minnesota United have secured a home Audi MLS Cup Playoffs game, with the Loons seeking their first postseason win against a Colorado Rapids side eager to play the underdog role in a Round One showdown at Allianz Field Nov. 22.