### PR TITLE
Sporting Kansas City vs. Minnesota United FC | December 3, 2020

### DIFF
--- a/_posts/mnufc/2020-12-3-Sporting-Kansas-City-vs-Minnesota-United-FC.md
+++ b/_posts/mnufc/2020-12-3-Sporting-Kansas-City-vs-Minnesota-United-FC.md
@@ -1,0 +1,16 @@
+---
+title: Sporting Kansas City vs. Minnesota United FC | December 3, 2020
+date: Thu Dec 03 2020 00:00:00 GMT+0000 (Coordinated Universal Time)
+permalink: 2020_12_3_sporting_kansas_city_vs_minnesota_united_fc_md
+excerpt: Upsets against the top two seeds in the East opened the door for Sporting Kansas City to have home field advantage throughout the remainder of the Audi 2020 MLS Cup Playoffs, but Minnesota United will come to Children's Mercy Park confident coming off their first playoff win when the sides square off Dec. 3 in the Western Conference Semifinals. 
+author: Matt Erickson (ME)
+layout: post
+tags:
+  - mnufc
+  - soccer
+  - auto-post
+hidden: true
+---
+<div class='soccer-video-wrapper'>
+    <iframe class='soccer-video' width='100%' height='auto' frameborder='0' allowfullscreen src='https://www.mnufc.com/iframe-video?brightcove_id=6214078478001&brightcove_player_id=default&brightcove_account_id=5534894110001'></iframe>
+  </div>


### PR DESCRIPTION
Upsets against the top two seeds in the East opened the door for Sporting Kansas City to have home field advantage throughout the remainder of the Audi 2020 MLS Cup Playoffs, but Minnesota United will come to Children's Mercy Park confident coming off their first playoff win when the sides square off Dec. 3 in the Western Conference Semifinals. 