### PR TITLE
Seattle Sounders FC vs. Minnesota United FC | December 07, 2020

### DIFF
--- a/_posts/mnufc/2020-12-7-Seattle-Sounders-FC-vs-Minnesota-United-FC.md
+++ b/_posts/mnufc/2020-12-7-Seattle-Sounders-FC-vs-Minnesota-United-FC.md
@@ -1,0 +1,16 @@
+---
+title: Seattle Sounders FC vs. Minnesota United FC | December 07, 2020
+date: Mon Dec 07 2020 00:00:00 GMT+0000 (Coordinated Universal Time)
+permalink: 2020_12_7_seattle_sounders_fc_vs_minnesota_united_fc_md
+excerpt: Seattle Sounders FC are 90 minutes away from their fourth trip to MLS Cup in five years, while Minnesota United are 90 minutes away from a first-ever trip to the title match when the sides square off in the Western Conference Final at Lumen Field Monday night.
+author: Matt Erickson (ME)
+layout: post
+tags:
+  - mnufc
+  - soccer
+  - auto-post
+hidden: true
+---
+<div class='soccer-video-wrapper'>
+    <iframe class='soccer-video' width='100%' height='auto' frameborder='0' allowfullscreen src='https://www.mnufc.com/iframe-video?brightcove_id=6214805976001&brightcove_player_id=default&brightcove_account_id=5534894110001'></iframe>
+  </div>


### PR DESCRIPTION
Seattle Sounders FC are 90 minutes away from their fourth trip to MLS Cup in five years, while Minnesota United are 90 minutes away from a first-ever trip to the title match when the sides square off in the Western Conference Final at Lumen Field Monday night.